### PR TITLE
fix: fetchHostDescription don't work with Nuke

### DIFF
--- a/Support/Library/ofxsImageEffect.cpp
+++ b/Support/Library/ofxsImageEffect.cpp
@@ -1969,7 +1969,7 @@ namespace OFX {
         gHostDescription.supportsCustomAnimation    = hostProps.propGetInt(kOfxParamHostPropSupportsCustomAnimation) != 0;
         gHostDescription.supportsParametricParameter = gParametricParameterSuite != 0;
 #ifdef OFX_SUPPORTS_OPENGLRENDER
-        gHostDescription.supportsOpenGLRender = hostProps.propGetString(kOfxImageEffectPropOpenGLRenderSupported, 0) == "true" && gOpenGLRenderSuite != 0;
+        gHostDescription.supportsOpenGLRender = gOpenGLRenderSuite != 0 && hostProps.propGetString(kOfxImageEffectPropOpenGLRenderSupported, 0, false) == "true";
 #endif
 #ifdef OFX_EXTENSIONS_NUKE
         gHostDescription.supportsCameraParameter    = gCameraParameterSuite != 0;


### PR DESCRIPTION
kOfxImageEffectPropOpenGLRenderSupported can be unknown to host if host doesn't support gOpenGLRenderSuite (Nuke for example)
then we can get an exception here and plugin construction will fail
so gOpenGLRenderSuite check must be done first and/or hostProps.propGetString(kOfxImageEffectPropOpenGLRenderSupported) must not raise exception