### PR TITLE
Support: add getPluginFilePath

### DIFF
--- a/Support/include/ofxsImageEffect.h
+++ b/Support/include/ofxsImageEffect.h
@@ -1557,6 +1557,9 @@ namespace OFX {
 
     /** @brief Have we informed the host we support image tiling ? */
     bool getSupportsTiles(void) const;
+
+    /** @brief get plugin file path */
+    const std::string getPluginFilePath(void) { return _effectProps.propGetString(kOfxPluginPropFilePath); }
     
 #ifdef OFX_EXTENSIONS_NUKE
     /** @brief indicate that a plugin or host can handle transform effects */


### PR DESCRIPTION
I needed access to the plugin folder through the c++ wrapper and couldn't find a function for this.